### PR TITLE
Bugfix: error location to save default.yml in vagrant box

### DIFF
--- a/packer/scripts/infrasim-box/config_change.sh
+++ b/packer/scripts/infrasim-box/config_change.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # modify bmc interface in box
-sed -i "s/\(interface: \).*/\1enp0s8/g" /usr/local/infrasim/etc/infrasim.yml
+sed -i "s/\(interface: \).*/\1enp0s8/g" ${HOME}/.infrasim/.node_map/default.yml

--- a/packer/scripts/infrasim-compute.sh
+++ b/packer/scripts/infrasim-compute.sh
@@ -18,4 +18,4 @@ sleep 1
 
 # init infrasim service
 infrasim init
-wget https://raw.githubusercontent.com/InfraSIM/tools/master/packer/scripts/infrasim.yml -O /home/infrasim/.infrasim/.node_map/default.yml -q
+wget https://raw.githubusercontent.com/InfraSIM/tools/master/packer/scripts/infrasim.yml -O ${HOME}/.infrasim/.node_map/default.yml -q


### PR DESCRIPTION
In vagrant box, the user is "vagrant", not "infrasim".
So in infrasim-compute.sh, the yaml file should be stored to ${HOME}/.node_map/