### PR TITLE
chown of source code directory to infrasim

### DIFF
--- a/packer/scripts/infrasim-compute.sh
+++ b/packer/scripts/infrasim-compute.sh
@@ -11,6 +11,7 @@ sleep 1
 
 # install infrasim-compute
 git clone https://github.com/InfraSIM/infrasim-compute.git
+chown -R infrasim:infrasim infrasim-compute
 cd infrasim-compute
 pip install -r requirements.txt
 python setup.py install


### PR DESCRIPTION
Packer uses "sudo" when executing scripts. When user wants modify anything
in source code directory "infrasim-compute", sudo permission is needed,
which is not user-friendly.