### PR TITLE
Bugfix: chown uname/groupname error

### DIFF
--- a/packer/scripts/infrasim-compute.sh
+++ b/packer/scripts/infrasim-compute.sh
@@ -11,7 +11,7 @@ sleep 1
 
 # install infrasim-compute
 git clone https://github.com/InfraSIM/infrasim-compute.git
-chown -R infrasim:infrasim infrasim-compute
+chown -R "`id -un`:`id -gn`" infrasim-compute
 cd infrasim-compute
 pip install -r requirements.txt
 python setup.py install


### PR DESCRIPTION
Sorry I made a mistake in this shared script again!
In vagrant box, the user we use is "vagrant", not "infrasim".

Solution: read username/groupname from "id" command, not to hard code
it.