### PR TITLE
Define network as variable

### DIFF
--- a/packer/infrasim-vmware.json
+++ b/packer/infrasim-vmware.json
@@ -9,9 +9,13 @@
         "numvcpus": "2",
         "nic_name": "vmxnet3",
         "nic0_number": "160",
+        "network0": "ADMIN",
         "nic1_number": "192",
+        "network1": "BMC",
         "nic2_number": "224",
-        "nic3_number": "256"
+        "network2": "CONTROL",
+        "nic3_number": "256",
+        "network3": "DATA"
     },
     "provisioners": [
         {
@@ -88,22 +92,22 @@
             },
             "vmx_data_post":{
                 "displayname": "infrasim-compute",
-                "ethernet0.networkName": "ADMIN",
+                "ethernet0.networkName": "{{ user `network0` }}",
                 "ethernet0.virtualDev": "{{ user `nic_name` }}",
                 "ethernet0.present": "TRUE",
-                "ethernet0.pcislotnumber": "{{ user `nic0_num` }}",
-                "ethernet1.networkName": "BMC",
+                "ethernet0.pcislotnumber": "{{ user `nic0_number` }}",
+                "ethernet1.networkName": "{{ user `network1` }}",
                 "ethernet1.virtualDev": "{{ user `nic_name` }}",
                 "ethernet1.present": "TRUE",
-                "ethernet1.pcislotnumber": "{{ user `nic1_num` }}",
-                "ethernet2.networkName": "CONTROL",
+                "ethernet1.pcislotnumber": "{{ user `nic1_number` }}",
+                "ethernet2.networkName": "{{ user `network2` }}",
                 "ethernet2.virtualDev": "{{ user `nic_name` }}",
                 "ethernet2.present": "TRUE",
-                "ethernet2.pcislotnumber": "{{ user `nic2_num` }}",
-                "ethernet3.networkName": "DATA",
+                "ethernet2.pcislotnumber": "{{ user `nic2_number` }}",
+                "ethernet3.networkName": "{{ user `network3` }}",
                 "ethernet3.virtualDev": "{{ user `nic_name` }}",
                 "ethernet3.present": "TRUE",
-                "ethernet3.pcislotnumber": "{{ user `nic3_num` }}"
+                "ethernet3.pcislotnumber": "{{ user `nic3_number` }}"
             }
         }
     ]


### PR DESCRIPTION
User can use below command to change network during runtime.

packer build -var 'network0=<interface0>' -var 'network1=<interface1>' ... infrasim-vmware.json