### PR TITLE
Add ansible playbook for scale control

### DIFF
--- a/ansibleplaybook/README.md
+++ b/ansibleplaybook/README.md
@@ -1,0 +1,215 @@
+# Ansible Playbook For infrasim-compute
+
+This playbook contains ansible tasks for infrasim installation and basic commands.
+
+## Setup ansible and set ansible variables.
+
+	sudo apt-get install ansible
+    sudo apt-get install sshpass
+    sudo apt-get install python-pip
+    sudo pip install -U ansible
+    export ANSIBLE_HOST_KEY_CHECKING=False
+
+You can also edit /etc/ansible/ansible.cfg to uncomment **host_key_checking = False**.
+Note that ansible 2.2.0.0+ is needed for running this playbook.
+
+## Structure of this playbook
+
+    group_vars/
+        computes
+
+    inventory_example
+
+    roles/
+        commoncmd/
+            tasks/
+                main.yml
+        configcmd/
+            tasks/
+                main.yml
+        installation/
+            tasks/
+                main.yml
+        nodecmd/
+            tasks/
+                main.yml
+        uninstallation/
+            tasks/
+                main.yml
+    
+    site.yml
+
+**site.yml:** This is the master playbook, which contains two plays: Install InfraSIM and Manipulate InfraSIM.
+
+**inventory_example:** This is an example of inventory file. You can add hosts under any child group.
+
+	[quanta_d51]
+
+	[quanta_t41]
+
+	[dell_c6320]
+
+	[dell_r630]
+
+	[dell_r730]
+
+	[dell_r730xd]
+
+	[s2600kp]
+
+	[s2600tp]
+
+	[s2600wtt]
+
+	[computes:children]
+	quanta_d51
+	quanta_t41
+	dell_c6320
+	dell_r630
+	dell_r730
+	dell_r730xd
+	s2600kp
+	s2600tp
+	s2600wtt
+
+	[computes:vars]
+	ansible_connection=ssh
+	ansible_user=infrasim
+	ansible_port=22
+    ansible_ssh_pass=infrasim
+
+    ansible_become=true
+    ansible_become_pass=infrasim
+    ansible_become_flags= -S -n
+
+
+After you add hosts under the type groups, you could specify **group name** when you execute ansible command, then only the hosts under this group will execute the command. E.g., when you run `ansible-playbook -i inventory_example -l s2600tp -t init`, only s2600tp hosts will run infrasim init task.
+
+If you are not familiar with inventory file, you can refer to [Ansible Intro To Inventory](http://docs.ansible.com/ansible/intro_inventory.html).
+
+**roles:** Several roles under the main playbook.
+
+**group_vars:** Variables for inventory groups are defined under this directory. They will be overriden by command line variables.
+
+## How to use ansible playbook to run specified task
+
+    ansible-playbook -l <host pattern> -i <inventory_file> -t <tasktag> -e "variable1=xx variable2=xx" site.yml
+
+Example:
+
+    ansible-playbook -l quanta_d51 -i ./inventory_example -t nodestart  -e "node_name=default" site.yml
+
+This means to start a vnode named **default** for quanta_d51 servers defined in "./inventory_example" inventory.
+Note that:
+-l limits hosts by specified pattern, if it's omitted, all hosts under [computes] group will execute the task.
+
+## Provided tags for tasks and usage:
+
+### Installation:
+
+**install**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t install site.yml
+
+Install infrasim on specified hosts.
+
+### Uninstallation
+
+**uninstall**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t uninstall site.yml
+
+Uninstall infrasim from specified hosts.
+
+### Common Commands:
+
+**version**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t version site.yml
+
+Check infrasim version on specified hosts.
+
+**init**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t init site.yml
+
+Init infrasim service on specified hosts.
+After init, all your hosts are **quanta_d51**, you need to run **changetype** or **updateconfig** task to change the node type.
+
+**help**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t help site.yml
+
+List infrasim CLI command options.
+
+### Config Commands:
+
+**configlist**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t configlist site.yml
+
+List mapped configurations for nodes in specified hosts.
+
+**changetype**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t changetype site.yml -e "node_name=<node_name> node_type=<node_type>"
+
+Change node type for node under specified hosts. If -e is not given, node_name=default, node_type=quanta_d51.
+
+**delconfig**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t delconfig site.yml -e "node_name=<node_name>"
+
+Delete node config of <node_name> in specified hosts.
+
+**addconfig**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t addconfig site.yml -e "node_name=<node_name> yml_path=xxx.yml"
+
+Add configuration mapping for <node_name> with yml file from **localhost**.
+\<yml_path\> is mandatory.
+    
+**updateconfig**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t addconfig site.yml -e "node_name=<node_name> yml_path=xxx.yml"
+
+Update configuration mapping for <node_name> with yml file from **localhost**.
+\<yml_path\> is mandatory.
+
+### Node Commands
+
+**nodestart**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t nodestart site.yml -e "node_name=<node_name>"
+
+Start node <node_name> on specified hosts.
+
+**nodestop**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t nodestop site.yml -e "node_name=<node_name>"
+
+Stop node <node_name> on specified hosts.
+
+**noderestart**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t noderestart site.yml -e "node_name=<node_name>"
+
+Restart node <node_name> on specified hosts.
+
+**nodedestroy**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t nodedestroy site.yml -e "node_name=<node_name>"
+
+Stop node <node_name> and tear down its runtime workspace on specified hosts.
+
+**nodestatus**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t nodestatus site.yml -e "node_name=<node_name>"
+
+Check node <node_name>'s running status on specified hosts.
+
+**nodeinfo**
+
+    ansible-playbook -l <host_pattern> -i <inventory_file> -t nodeinfo site.yml -e "node_name=<node_name>"
+
+Check node <node_name>'s specification on specified hosts.

--- a/ansibleplaybook/group_vars/computes
+++ b/ansibleplaybook/group_vars/computes
@@ -1,0 +1,13 @@
+---
+# In this file, the default values for variables are defined.
+# They will be overwritten by command line extra variables
+
+# git repo of infrasim
+source_repo: https://github.com/InfraSIM/infrasim-compute.git
+
+
+# default node name
+node_name: default
+
+# default node type
+node_type: quanta_d51

--- a/ansibleplaybook/inventory_example
+++ b/ansibleplaybook/inventory_example
@@ -1,0 +1,48 @@
+#  Example inventory file identifying hosts running virtual server service
+#  Grouping identifier is type of server that the infrasim-compute application
+#  is simulating
+#
+#   - Comments begin with the '#' character
+#   - Blank lines are ignored
+#   - Groups of hosts are delimited by [header] elements
+#   - You can enter hostnames or ip addresses
+#   - A hostname/ip can be a member of multiple groups
+
+[quanta_d51]
+
+[quanta_t41]
+
+[dell_c6320]
+
+[dell_r630]
+
+[dell_r730]
+
+[dell_r730xd]
+
+[s2600kp]
+
+[s2600tp]
+
+[s2600wtt]
+
+[computes:children]
+quanta_d51
+quanta_t41
+dell_c6320
+dell_r630
+dell_r730
+dell_r730xd
+s2600kp
+s2600tp
+s2600wtt
+
+[computes:vars]
+ansible_connection=ssh
+ansible_user=infrasim
+ansible_port=22
+ansible_ssh_pass=infrasim
+
+ansible_become=true
+ansible_become_pass=infrasim
+ansible_become_flags= -S -n

--- a/ansibleplaybook/roles/commoncmd/tasks/main.yml
+++ b/ansibleplaybook/roles/commoncmd/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# This task prints infrasim version
+- name: Show infrasim version
+  shell: infrasim version
+  register: out
+  tags: version
+- debug: var={{ item }}
+  with_items: out.stdout_lines 
+  tags: version
+
+# This task inits infrasim in remote hosts
+- name: Init infrasim service
+  shell: infrasim init 
+  become: true
+  register: out
+  tags: init 
+- debug: var={{ item }}
+  with_items: out.stdout_lines 
+  tags: init
+
+# This task shows infrasim command line help
+- name: Show infrasim CLI help
+  shell: infrasim -h
+  become: true
+  register: out
+  tags: help
+- debug: var={{ item }}
+  with_items: out.stdout_lines 
+  tags: help
+

--- a/ansibleplaybook/roles/configcmd/tasks/main.yml
+++ b/ansibleplaybook/roles/configcmd/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+# Task to list all mapped configurations
+- name: List configurations
+  shell: infrasim config list
+  become: true
+  register: out
+  tags: configlist
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+  tags: configlist
+
+# Task to change node type for specified node
+- lineinfile:
+    dest: "{{ lookup('env', 'HOME') }}/.infrasim/.node_map/{{ node_name }}.yml"
+    regexp: '^(type:(\s)).*'
+    line: '\1{{ node_type }}'
+    backrefs: true
+    state: present
+  become: false
+  register: out
+  tags: changetype
+- debug: var={{ item }}
+  with_items: out
+  tags: changetype
+
+
+# Task to remove node config
+- name: Delete node config
+  shell: infrasim config delete {{ node_name }}
+  become: true
+  register: out
+  tags: delconfig
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+  tags: delconfig
+
+
+# Tasks to transfer yml file to hosts and add to config
+- copy: 
+    src: "{{ yml_path }}"
+    dest: "{{ lookup('env','HOME') }}/tmp.yml"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0644
+  become: false
+  tags: addconfig
+  register: out
+- debug: var={{ item }}
+  with_items: out
+  tags: addconfig
+- name: Add node config 
+  shell: infrasim config add {{ node_name }} {{ lookup('env', 'HOME') }}/tmp.yml
+  become: true
+  tags: addconfig
+  register: out
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+  tags: addconfig
+
+# Tasks to transfer yml file to hosts and update node config
+- copy: 
+    src: "{{ yml_path }}"
+    dest: "{{ lookup('env','HOME') }}/tmp.yml"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0644
+  become: false
+  tags: updateconfig
+  register: out
+- debug: var={{ item }}
+  with_items: out
+  tags: updateconfig
+
+- name: Update node config
+  shell: infrasim config update {{ node_name }} {{ lookup('env', 'HOME') }}/tmp.yml
+  become: true
+  register: out
+  tags: updateconfig
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+  tags: updateconfig
+

--- a/ansibleplaybook/roles/installation/tasks/main.yml
+++ b/ansibleplaybook/roles/installation/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+
+# This task installs apt dependencies for infrasim
+- name: Apt install packages
+  become: true
+  apt: name={{ item }} state=latest
+  with_items:
+      - python-pip
+      - libpython-dev
+      - libssl-dev
+  register: out
+- debug: var={{ item }}
+  with_items: out
+
+# This task installs setuptools and upgrade pip version for infrasim
+- name: PIP install packages
+  become: true
+  pip: name={{ item }} state=latest
+  with_items:
+      - pip
+      - setuptools
+  register: out
+- debug: var={{ item }}
+  with_items: out
+
+# This task downloads infrasim-compute.git from repo
+- name: Download infrasim-compute source code
+  git: repo={{ source_repo }} dest={{ lookup('env', 'HOME') }}/infrasim-compute update=no
+  become: false
+  register: out
+- debug: var={{ item }}
+  with_items: out
+
+# This task installs pip dependencies for infrasim
+- name: Install Requirements
+  pip: chdir={{ lookup('env', 'HOME') }}/infrasim-compute requirements=requirements.txt
+  become: false
+  register: out
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+
+# This task installs infrasim
+- name: Install InfraSIM from source
+  shell: python setup.py install chdir={{ lookup('env', 'HOME') }}/infrasim-compute
+  become: true
+  register: out
+- debug: var={{ item }}
+  with_items: out.stdout_lines

--- a/ansibleplaybook/roles/nodecmd/tasks/main.yml
+++ b/ansibleplaybook/roles/nodecmd/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+
+# This task starts a vnode with specified name
+- name: Start vnode
+  shell: infrasim node start {{ node_name }}
+  become: true
+  register: out
+  tags: nodestart
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: nodestart
+
+# This task stops a vnode with specified name
+- name: Stop vnode
+  shell: infrasim node stop {{ node_name }}
+  become: true
+  register: out
+  tags: nodestop
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: nodestop
+
+# This task restarts a vnode with specified name
+- name: Restart vnode
+  shell: infrasim node restart {{ node_name }}
+  become: true
+  register: out
+  tags: noderestart
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: noderestart
+
+# This task destroys a vnode with specified name
+- name: Destroy vnode 
+  shell: infrasim node destroy {{ node_name }}
+  become: true
+  register: out
+  tags: nodedestroy
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: nodedestroy
+
+# This task checks vnode's status with specified name
+- name: View vnode status
+  shell: infrasim node status {{ node_name }}
+  become: true
+  register: out
+  tags: nodestatus
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: nodestatus
+
+# This task list a vnode's information with specified name
+- name: View vnode information
+  shell: infrasim node info {{ node_name }}
+  become: true
+  register: out
+  tags: nodeinfo
+- debug: var={{item}}
+  with_items: out.stdout_lines
+  tags: nodeinfo
+
+# This task starts a vnode's ipmi-console service
+- name: Start ipmi-console
+  shell: ipmi-console start {{ node_name }}
+  become: true
+  register: out
+  tags: startconsole
+- debug: var={{item}}
+  with_items: out
+  tags: startconsole
+
+# This task stops a vnode's ipmi-console service
+- name: Stop ipmi-console
+  shell: ipmi-console stop {{ node_name }}
+  become: true
+  register: out
+  tags: stopconsole
+- debug: var={{item}}
+  with_items: out
+  tags: stopconsole

--- a/ansibleplaybook/roles/uninstallation/tasks/main.yml
+++ b/ansibleplaybook/roles/uninstallation/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+# This task uninstalls infrasim-compute
+- name: Uninstall infrasim
+  become: true
+  shell: echo "y" | pip uninstall infrasim-compute
+  register: out
+- debug: var={{ item }}
+  with_items: out.stdout_lines
+

--- a/ansibleplaybook/site.yml
+++ b/ansibleplaybook/site.yml
@@ -1,0 +1,22 @@
+---
+- name: Install InfraSIM
+  hosts: computes
+  tags: install
+
+  roles:
+  - installation
+
+- name: Uninstall InfraSIM
+  hosts: computes
+  tags: uninstall
+
+  roles:
+  - uninstallation
+
+- name: Manipulate InfraSIM
+  hosts: computes
+
+  roles:
+  - commoncmd
+  - configcmd
+  - nodecmd


### PR DESCRIPTION
Create a playbook to control multiple hosts in one command.
There are five roles in the playbook:
* installation: steps to install infrasim-compute on a pure ubuntu
16.04.

* uninstallation: pip uninstall infrasim-compute.

* commoncmd: including commands infrasim version/init/help.

* configcmd: including commands infrasim config add/delete/update and modification of node type.

* nodecmd: including commands infrasim node
start/stop/restart/destroy/status/info.