### PR TITLE
Add linux aio support in qemu configure

### DIFF
--- a/deb_builder/qemu-package.sh
+++ b/deb_builder/qemu-package.sh
@@ -46,7 +46,7 @@ pushd $src
 ./configure --prefix=/usr/local --target-list=${ARCH}-linux-user,${ARCH}-softmmu \
     --disable-smartcard --disable-seccomp --disable-glusterfs --disable-tpm \
     --disable-vhdx --disable-bluez --disable-gtk --disable-cocoa --disable-sdl --disable-xen \
-    --without-system-pixman --enable-numa
+    --without-system-pixman --enable-numa --enable-linux-aio
 make -j${JOBS}
 
 #sudo apt-get build-dep libxen-dev

--- a/packer/scripts/infrasim-compute.sh
+++ b/packer/scripts/infrasim-compute.sh
@@ -3,7 +3,7 @@
 export LC_ALL=C
 
 # install dependency for infrasim-compute
-apt-get install -y python-pip libssl-dev libpython-dev git bridge-utils
+apt-get install -y python-pip libssl-dev libpython-dev git bridge-utils libaio-dev
 
 pip install setuptools
 pip install --upgrade pip


### PR DESCRIPTION
1. add --enable-linux-aio in qemu configure for qemu make.
2. install libaio-dev in infrasim ova.