### PR TITLE
Added infrasim-as-service script for packer build

### DIFF
--- a/packer/scripts/infrasim-as-service.sh
+++ b/packer/scripts/infrasim-as-service.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This file write a systemd configuration,
+# then enable a default infrasim node to
+# be started with system.
+cat >> /etc/systemd/system/infrasim.service <<EOF
+[Unit]
+Description=InfraSIM Compute Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/infrasim node start
+ExecStop=/usr/local/bin/infrasim node stop
+ExecReload=/usr/local/bin/infrasim node restart
+Restart=on-failure
+Environment=HOME=/home/infrasim/
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+
+EOF
+
+systemctl enable infrasim
+


### PR DESCRIPTION
When we decides to make this feature launched, script shall be
called in packer/infrasim-vmware.json and packer/infrasim-box.json