### PR TITLE
Hotfix/wrong_return

### DIFF
--- a/data_generater/gen_emu_utility.py
+++ b/data_generater/gen_emu_utility.py
@@ -900,7 +900,7 @@ def main():
     py_version = sys.version_info
     if not (py_version[0] is 2 and py_version[1] is 7):
         print "Warning: please install Python 2.7 first."
-    return
+        return
 
     dump = False
     analysis = False


### PR DESCRIPTION
The `return` has a wrong indent, which makes every run return here.