### PR TITLE
feature/to create Ubuntu image with packer QEMU builder

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -22,6 +22,14 @@ The output file is named infrasim-compute.box.
 
 The output file is named infrasim-compute.ova.
 
+## To build QEMU ubuntu image
+
+    git clone https://github.com/InfraSIM/tools.git
+    cd tools/packer
+    packer build infrasim-qemu.json
+
+The output file is named qemu-ubuntu16.04-image in folder packer/qemu-image.
+
 ## How to Deploy
 
 ### For vmware:

--- a/packer/http/qemu/preseed.cfg
+++ b/packer/http/qemu/preseed.cfg
@@ -1,0 +1,31 @@
+### Network configuration
+d-i netcfg/get_hostname string ubuntu
+
+choose-mirror-bin mirror/http/proxy string
+d-i debian-installer/framebuffer boolean false
+d-i debconf/frontend select noninteractive
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto/method string regular
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i pkgsel/include string openssh-server
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+# Default user
+d-i passwd/user-fullname string infrasim
+d-i passwd/username string infrasim
+d-i passwd/user-password-crypted password $1$I/uhCHOZ$wOwVqZUMnIFcg7JYi19AU.
+

--- a/packer/infrasim-qemu.json
+++ b/packer/infrasim-qemu.json
@@ -1,0 +1,92 @@
+{
+    "variables": {
+        "disk_size": "65536",
+        "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso",
+        "gui_disable": "true",
+        "memsize": "5120",
+        "cpus": "2",
+        "output": "infrasim-ubuntu16.04.img",
+        "hostname": "infrasim",
+        "ssh_fullname": "infrasim",
+        "ssh_password": "infrasim",
+        "ssh_username": "infrasim"
+    },
+    "provisioners": [
+        {
+            "type": "shell",
+            "execute_command": "echo '{{ user `ssh_password` }}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+            "scripts": [
+                "scripts/infrasim-qemu/base.sh",
+                "scripts/infrasim-qemu/dhcp_setting.sh",
+                "scripts/infrasim-qemu/nvme-cli.sh",
+                "scripts/cleanup.sh"
+            ]
+        }
+    ],
+    "builders": [
+        {
+            "type": "qemu",
+            "iso_url": "{{ user `iso_url` }}",
+            "iso_checksum": "10fcd20619dce11fe094e960c85ba4a9",
+            "iso_checksum_type": "md5",
+            "output_directory": "qemu-image",
+            "shutdown_command": "sudo shutdown -P now",
+            "disk_size": "{{ user `disk_size` }}",
+            "format": "qcow2",
+            "headless": "{{ user `gui_disable` }}",
+            "accelerator": "kvm",
+            "http_directory": "http",
+            "http_port_min": 10082,
+            "http_port_max": 10089,
+            "ssh_host_port_min": 2222,
+            "ssh_host_port_max": 2229,
+            "ssh_username": "{{ user `ssh_username` }}",
+            "ssh_password": "{{ user `ssh_password` }}",
+            "ssh_port": 22,
+            "ssh_wait_timeout": "3600s",
+            "vm_name": "qemu-ubuntu16.04-image",
+            "net_device": "e1000",
+            "disk_interface": "scsi",
+            "boot_wait": "5s",
+            "vnc_bind_address": "0.0.0.0",
+            "qemuargs": [
+                [ "--enable-kvm"],
+                [ "-smp", 2],
+                [ "-m", "2048" ]
+            ],
+            "boot_command": [
+                "<enter><wait><f6><esc>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs>",
+                "/install/vmlinuz<wait>",
+                " auto<wait>",
+                " console-setup/ask_detect=false<wait>",
+                " console-setup/layoutcode=us<wait>",
+                " console-setup/modelcode=pc105<wait>",
+                " debconf/frontend=noninteractive<wait>",
+                " debian-installer=en_US<wait>",
+                " hostname={{ user `hostname` }}",
+                " fb=false<wait>",
+                " initrd=/install/initrd.gz<wait>",
+                " kbd-chooser/method=us<wait>",
+                " keyboard-configuration/layout=USA<wait>",
+                " keyboard-configuration/variant=USA<wait>",
+                " locale=en_US<wait>",
+                " netcfg/get_hostname=infrasim<wait>",
+                " noapic<wait>",
+                " preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/qemu/preseed.cfg<wait>",
+                " -- <wait>",
+                "<enter><wait>"
+            ]
+        }
+    ]
+}

--- a/packer/scripts/infrasim-qemu/base.sh
+++ b/packer/scripts/infrasim-qemu/base.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+perl -p -i -e 's#http://us.archive.ubuntu.com/ubuntu#http://mirror.rackspace.com/ubuntu#gi' /etc/apt/sources.list
+
+# reduces package installs to bare mininums
+cat <<EOAPT > /etc/apt/apt.conf
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+Acquire::Languages "none";
+Acquire::GzipIndexes "true";
+Acquire::CompressionTypes::Order:: "gz";
+Dir::Cache::srcpkgcache "";
+Dir::Cache::pkgcache "";
+EOAPT
+
+# Update the box
+apt-get -y update >/dev/null
+apt-get -y install facter linux-headers-$(uname -r) git build-essential zlib1g-dev libssl-dev libreadline-gplv2-dev unzip python-software-properties make gcc devscripts >/dev/null
+
+# Tweak sshd to prevent DNS resolution (speed up logins)
+echo 'UseDNS no' >> /etc/ssh/sshd_config
+
+# Remove 5s grub timeout to speed up booting
+cat <<EOF > /etc/default/grub
+# If you change this file, run 'update-grub' afterwards to update
+# /boot/grub/grub.cfg.
+
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=0
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+GRUB_CMDLINE_LINUX="debian-installer=en_US"
+EOF
+
+update-grub
+
+# In case your control/data network is not connected to a DHCP yet
+# Here we set the waiting time to 10s to reduce boot time
+sed -i "s/TimeoutStartSec.*/TimeoutStartSec=30s/g" /lib/systemd/system/networking.service
+sed -i "s/^timeout .*/timeout 5;/g" /etc/dhcp/dhclient.conf
+
+# add infrasim to have no password asked for sudo privilege
+touch /etc/sudoers.d/infrasim
+chmod 666 /etc/sudoers.d/infrasim
+echo "infrasim ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/infrasim
+chmod 644 /etc/sudoers.d/infrasim

--- a/packer/scripts/infrasim-qemu/dhcp_setting.sh
+++ b/packer/scripts/infrasim-qemu/dhcp_setting.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "cleaning up dhcp leases"
+rm -f /var/lib/dhcp/*
+echo "Base network interface config"
+cat > /etc/network/interfaces << EOF
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto enp0s3
+iface enp0s3 inet dhcp
+
+auto enp0s8
+iface enp0s8 inet dhcp
+
+auto enp0s9
+iface enp0s9 inet static
+address 0.0.0.0
+post-up ifconfig enp0s9 promisc
+
+auto enp0s10
+iface enp0s10 inet static
+address 0.0.0.0
+post-up ifconfig enp0s10 promisc
+
+EOF

--- a/packer/scripts/infrasim-qemu/nvme-cli.sh
+++ b/packer/scripts/infrasim-qemu/nvme-cli.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export LC_ALL=C
+#Install from apt sources
+# install nvme-cli
+#apt-get install python-software-properties -y
+#add-apt-repository ppa:sbates << EOF
+#
+#EOF
+#apt-get update
+#apt-get install nvme-cli -y
+#nvme list
+
+git clone https://github.com/linux-nvme/nvme-cli.git
+chown -R "`id -un`:`id -gn`" nvme-cli
+cd nvme-cli
+echo 'infrasim' | sudo -S make
+echo 'infrasim' | sudo -S make install
+sleep 1
+
+# Test the nvme-cli code
+echo 'infrasim' | sudo -S nvme list


### PR DESCRIPTION
Add configure file to create Ubuntu image with packer QEMU builder.
The output file is a qcow2 image with Ubuntu system and tools (e.g.: nvme-cli) installed.