### PR TITLE
Remove pip update in packer build

### DIFF
--- a/packer/scripts/infrasim-compute.sh
+++ b/packer/scripts/infrasim-compute.sh
@@ -6,7 +6,6 @@ export LC_ALL=C
 apt-get install -y python-pip libssl-dev libpython-dev git bridge-utils libaio-dev
 
 pip install setuptools
-pip install --upgrade pip
 sleep 1
 
 # install infrasim-compute


### PR DESCRIPTION
Remove pip update in packer/scripts/infrasim-compute.sh.
There is some import issue with latest pip 10.0.0.
Error message: 'ImportError: cannot import name main'
This error is blocking infrasim-compute ova build job.