### PR TITLE
Update ca-certificate in ova build

### DIFF
--- a/packer/infrasim-vmware.json
+++ b/packer/infrasim-vmware.json
@@ -15,9 +15,24 @@
         "nic2_number": "224",
         "network2": "CONTROL",
         "nic3_number": "256",
-        "network3": "DATA"
+        "network3": "DATA",
+        "crt_file_path": "../../EMCCA.crt"
     },
     "provisioners": [
+        {
+            "type": "file",
+            "source": "{{ user `crt_file_path` }}",
+            "destination": "/tmp/EMCCA.crt"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "cp /tmp/EMCCA.crt /usr/share/ca-certificates/",
+                "bash -c 'echo EMCCA.crt >> /etc/ca-certificates.conf'",
+                "update-ca-certificates"
+            ],
+            "execute_command": "echo 'infrasim' |sudo -S bash '{{.Path}}'"
+        },
         {
             "type": "shell",
             "scripts": [


### PR DESCRIPTION
Add step to update-ca-certificate in ova build against `infrasim init -f -e "deb-resources"`.